### PR TITLE
Added dependency fetching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM golang:1.12.5-alpine as builder
 ARG VERSION
+ENV GO111MODULE=on
 RUN mkdir -p /go/src/github.com/TimothyYe/bing-wallpaper
 WORKDIR /go/src/github.com/TimothyYe/bing-wallpaper
 RUN cd /go/src/github.com/TimothyYe/bing-wallpaper
 COPY . .
+RUN apk --no-cache add git \
+	&& go get github.com/beevik/etree \
+	&& go get github.com/gin-gonic/gin \
+	&& go get github.com/spf13/cobra \
+	&& apt del git
 RUN go build -o ./bw/bw ./bw/main.go
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
 FROM golang:1.12.5-alpine as builder
 ARG VERSION
-ENV GO111MODULE=on
 RUN mkdir -p /go/src/github.com/TimothyYe/bing-wallpaper
 WORKDIR /go/src/github.com/TimothyYe/bing-wallpaper
 RUN cd /go/src/github.com/TimothyYe/bing-wallpaper
 COPY . .
 RUN apk --no-cache add git \
-	&& go get github.com/beevik/etree \
-	&& go get github.com/gin-gonic/gin \
-	&& go get github.com/spf13/cobra \
-	&& apt del git
-RUN go build -o ./bw/bw ./bw/main.go
+    && GO111MODULE=on go build -o ./bw/bw ./bw/main.go
 
 
 FROM alpine


### PR DESCRIPTION
If you try to build the project according to the instructions in the README, the build will fail as go cannot locate the three dependencies. This PR adds support for installing them during the build process, making it build just fine without further preparations.