### PR TITLE
Change README en-GB market example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A RESTful API to fetch daily wallpaper from Bing.com
 * `format` The response format, can be `json` or `image`. __If response format is set as `image`, you will be redirected to the wallpaper image directly__.
 * `image_format` The format of the wallpaper image, available values are `jpg` or `webp`. The default value is `jpg`.
 * `index` The index of wallpaper, starts from 0. By default, `0` means to get today's image, `1` means to get the image of yesterday, and so on. Or you can specify it as `random` to choose a random index between 0 and 7.
-* `mkt` The region parameter, the default value is `zh-CN`, you can also use `en-US`, `ja-JP`, `en-AU`, `en-UK`, `de-DE`, `en-NZ`, `en-CA`. You can also set it as `random` to choose the region randomly.
+* `mkt` The region parameter, the default value is `zh-CN`, you can also use `en-US`, `ja-JP`, `en-AU`, `en-GB`, `de-DE`, `en-NZ`, `en-CA`. You can also set it as `random` to choose the region randomly.
 
 ### Example
 


### PR DESCRIPTION
Just gave this a go, looks like en-UK isn't supported but en-GB is