### PR TITLE
chore: update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM golang:1.20.2-alpine3.17 as builder
-ARG VERSION
-RUN mkdir -p /go/src/github.com/TimothyYe/bing-wallpaper
+
 WORKDIR /go/src/github.com/TimothyYe/bing-wallpaper
-RUN cd /go/src/github.com/TimothyYe/bing-wallpaper
 COPY . .
 RUN apk --no-cache add git build-base make gcc libtool musl-dev \
 	&& GO111MODULE=on go build -o ./bw/bw ./bw/main.go
@@ -17,7 +15,6 @@ RUN apk --no-cache add ca-certificates tzdata sqlite \
 # See https://stackoverflow.com/questions/34729748/installed-go-binary-not-found-in-path-on-alpine-linux-docker
 RUN mkdir /lib64 && ln -s /lib/libc.musl-`uname -m`.so.1 /lib64/ld-linux-`uname -m`.so.2
 
-RUN mkdir /bw
 WORKDIR /bw
 COPY --from=builder /go/src/github.com/TimothyYe/bing-wallpaper/bw/bw /bw/bw
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.20.2-alpine3.17 as builder
-
 WORKDIR /go/src/github.com/TimothyYe/bing-wallpaper
 COPY . .
 RUN apk --no-cache add git build-base make gcc libtool musl-dev \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 		go build -o ./bw/${BINARY} ./bw/main.go
 release:
 		# Build image
-		docker build -t "timothyye/bing:${DATE}" -f Dockerfile .
+		docker build -t "timothyye/bing:${DATE}" .
 		docker push "timothyye/bing:${DATE}"
 test:
 		go test .


### PR DESCRIPTION
## What does this PR do?
Dockerfile tidy

+ removed the `VERSION` arg which is never used in build
+ not necessary to create a workdir with `mkdir`, docker runtime will create it for us, by using the `WORKDIR` directive
+ not necessary to cd into the workdir, by using the `WORKDIR` directive, the current working directory will be switch to it by default. For more info, please check: https://docs.docker.com/engine/reference/builder/#workdir
+ We'll run make build from the root dir of the project, so not necessary to explicitly specify the Dockerfile path

According to the [official docs](https://docs.docker.com/engine/reference/builder/#workdir):

> The WORKDIR instruction sets the working directory for any RUN, CMD, ENTRYPOINT, COPY and ADD instructions that follow it in the Dockerfile. If the WORKDIR doesn't exist, it will be created even if it's not used in any subsequent Dockerfile instruction.

 With all the changes introduced in this PR, I've tested on my laptop, with `docker build` and `docker run`. And it still works:


![Screenshot 2023-12-08 221642](https://github.com/TimothyYe/bing-wallpaper/assets/28262755/a140a8c2-7ed0-452f-9b33-2337546c0b28)
